### PR TITLE
feat: Implemented submit functionality for alerts panel

### DIFF
--- a/src/components/AlertsPanel.tsx
+++ b/src/components/AlertsPanel.tsx
@@ -5,6 +5,7 @@ import enUS from "antd/locale/en_US";
 import React, { useState } from "react";
 import earthquakeService from "../services/earthquake";
 import dayjs from "dayjs";
+import { notify } from "../utils/notificationHelper";
 
 const waitTime = (time: number = 100) => {
   return new Promise((resolve) => {
@@ -110,7 +111,30 @@ export default () => {
         <a
           key="submit"
           onClick={() => {
-            setDataSource(dataSource.filter((item) => item.id !== record.id));
+            if (record.hasDamage === "" || record.needsCommandCenter === "") {
+              notify(
+                "error",
+                "Please update both hasDamage and needsCommandCenter before submit",
+              );
+            } else {
+              const updatedAlert = {
+                ...record,
+                status: "PROCESSED",
+                processedTime: dayjs().format("YYYY-MM-DD HH:mm:ss"),
+              };
+
+              earthquakeService
+                .updateAlert(record.id, updatedAlert)
+                .then(() => {
+                  setDataSource(
+                    dataSource.filter((item) => item.id !== record.id),
+                  );
+                  notify("success", `You have responded to alert ${record.id}`);
+                })
+                .catch((error) => {
+                  notify("error", error.message);
+                });
+            }
           }}
         >
           Submit

--- a/src/services/earthquake.js
+++ b/src/services/earthquake.js
@@ -10,4 +10,8 @@ const getAlerts = async () => {
   return response;
 };
 
-export default { create, getAlerts };
+const updateAlert = (id, updatedData) => {
+  return axios.put(baseUrl + `/alerts/${id}`, updatedData);
+};
+
+export default { create, getAlerts, updateAlert };

--- a/tests/components/AlertsPanel.test.jsx
+++ b/tests/components/AlertsPanel.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, waitFor, screen, fireEvent } from "@testing-library/react";
 import AlertsPanel from "../../src/components/AlertsPanel";
 import earthquakeService from "../../src/services/earthquake";
+import { notify } from "../../src/utils/notificationHelper";
 
 // mock service
 vi.mock("../../src/services/earthquake", () => ({
@@ -9,6 +10,11 @@ vi.mock("../../src/services/earthquake", () => ({
     getAlerts: vi.fn(),
   },
 }));
+vi.mock("../../src/utils/notificationHelper", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("axios");
 
 const mockData = {
   data: {
@@ -20,7 +26,7 @@ const mockData = {
         severityLevel: 2,
         originTime: "2025-05-09T15:46:13",
         hasDamage: 1,
-        needsCommandCenter: 0,
+        needsCommandCenter: "",
       },
     ],
   },
@@ -51,6 +57,22 @@ describe("AlertsPanel component", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Submit")).toBeInTheDocument();
+    });
+  });
+
+  it("should show error notification when hasDamage or needsCommandCenter is empty on submit", async () => {
+    render(<AlertsPanel />);
+
+    const submitButton = await screen.findByText("Submit");
+
+    fireEvent.click(submitButton);
+
+    // Wait for the error notification
+    await waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        "error",
+        "Please update both hasDamage and needsCommandCenter before submit",
+      );
     });
   });
 });

--- a/tests/services/earthquake.test.js
+++ b/tests/services/earthquake.test.js
@@ -40,4 +40,21 @@ describe("earthquake service", () => {
     );
     expect(result).toEqual(responseData);
   });
+
+  it("should update earthquake alert", async () => {
+    const mockResponse = { data: "response data" };
+    axios.put.mockResolvedValue(mockResponse);
+
+    const id = 1;
+    const updatedData = { name: "Updated Alert" };
+
+    const result = await earthquakeService.updateAlert(id, updatedData);
+
+    expect(axios.put).toHaveBeenCalledWith(
+      `${import.meta.env.VITE_BACKEND_BASE_URL}/api/earthquake/alerts/1`,
+      updatedData,
+    );
+
+    expect(result).toEqual(mockResponse);
+  });
 });


### PR DESCRIPTION
## Description
 This PR updates the alert submission logic so that when an alert is submitted, its `status` field is explicitly set to `"PROCESSED"` and a `processedTime` is recorded.