### PR TITLE
fix: Updated nginx config to support proxy in k8s cluster

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,10 @@ http {
   sendfile        on;
   keepalive_timeout  65;
 
+  upstream backend {
+    server backend:8000; 
+  }
+
   server {
     listen 80;
     server_name _;
@@ -20,6 +24,22 @@ http {
 
     location / {
       try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+      proxy_pass http://backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /ws/ {
+      proxy_pass http://backend;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header Host $host;
     }
 
     location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?|ttf|svg|eot|otf)$ {


### PR DESCRIPTION
## Description
This PR updates the Nginx configuration to enable proper routing of frontend requests to the FastAPI backend service.

Changes include:
- Proxying all API requests under `/api/` to the backend service (`http://backend:8000`)
- Proxying WebSocket connections under `/ws/` to the backend using `ws://backend:8000`