### PR TITLE
fix: Fallback to empty string for undefined Vite URLs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ const App = () => {
     hasInitialized.current = true;
 
     ws.current = new WebSocket(
-      import.meta.env.VITE_BACKEND_WEBSOCKET_URL + "/ws/alerts",
+      `${import.meta.env.VITE_BACKEND_WEBSOCKET_URL || ""}/ws/alerts`,
     );
 
     ws.current.onmessage = (event) => {

--- a/src/services/earthquake.js
+++ b/src/services/earthquake.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-const baseUrl = `${import.meta.env.VITE_BACKEND_BASE_URL}/api/earthquake`;
+const baseUrl = `${import.meta.env.VITE_BACKEND_BASE_URL || ""}/api/earthquake`;
 
 const create = (newObject) => {
   return axios.post(baseUrl, newObject);

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-const baseUrl = `${import.meta.env.VITE_BACKEND_BASE_URL}`;
+const baseUrl = `${import.meta.env.VITE_BACKEND_BASE_URL || ""}`;
 const alertSuppressTimeUrl = baseUrl + "/api/settings/alert-suppress-time";
 
 export const getAlertSuppressTime = () => {


### PR DESCRIPTION
## Description
This PR updates how `VITE_BACKEND_BASE_URL` and `VITE_BACKEND_WEBSOCKET_URL` are accessed in the frontend code to prevent undefined from appearing in constructed URLs.