### PR TITLE
fix: Increased WebSocket timeout in Nginx config

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,6 +40,7 @@ http {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_set_header Host $host;
+      proxy_read_timeout 1d;
     }
 
     location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?|ttf|svg|eot|otf)$ {


### PR DESCRIPTION
## Description
This PR updates the Nginx configuration to support long-lived WebSocket connections by increasing the following timeout values:
- `proxy_read_timeout` set to 1 day