### PR TITLE
chore: Handled WebSocket ping messages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,8 +21,11 @@ const App = () => {
     );
 
     ws.current.onmessage = (event) => {
+      const message = event.data;
+      if (message === "ping") return;
+
       try {
-        const data = JSON.parse(event.data);
+        const data = JSON.parse(message);
         const alert =
           typeof data.alert === "string" ? JSON.parse(data.alert) : data.alert;
 


### PR DESCRIPTION
## Description
This PR adds a check to gracefully handle "ping" messages received over the WebSocket connection. Previously, receiving a plain string like "ping" would cause a `JSON.parse` error, as it is not valid JSON.