### PR TITLE
chore: Switched from Nginx proxy to GCE Ingress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN chown -R node /app
  
 # Production Stage
 FROM nginx:stable-alpine AS production
+COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes 1;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+
+  sendfile        on;
+  keepalive_timeout  65;
+
+  server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?|ttf|svg|eot|otf)$ {
+      expires 6M;
+      access_log off;
+      add_header Cache-Control "public";
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR removed nginx proxy configuration that handled `/api` and `/ws` routes forwarding to backend.